### PR TITLE
Don't word split on output of ps

### DIFF
--- a/src/xpub.sh
+++ b/src/xpub.sh
@@ -92,7 +92,7 @@ main () {
             exit 1
         fi
 
-        for xway in ${xways}; do
+        for xway in "${xways}"; do
             if echo "${xway}" | grep -E "^${xtty}" > /dev/null ; then
                 xdisplay="$(echo "${xway}" | awk '{print $4}')"
                 break


### PR DESCRIPTION
We only want line splitting on that output:

    tty1     30188 Xwayland :0 -rootless -terminate -listen 34 -listen 35 -wm